### PR TITLE
Feature reward text angle

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -43,6 +43,7 @@ class App extends Component {
           innerRadius={30}
           duration={5000}
           backgroundColor={"#c0392b"}
+          textAngle={"vertical"}
           getWinner={(value, index) => this.setState({ winnerValue: value, winnerIndex: index })}
         />
         <Button title="Press me" onPress={() => { this.child._onPress() }} />

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ knobSize | `Number` | 20 | Knoob size
 knoobSource | `Path` | knoob.png | Knoob source
 playButton | `render()` | example | Render method for tap to play button
 innerRadius | `Number` | 100 | Set inner radius size
+innerRadius | `Number` | 100 | Set inner radius size
+textAngle | `String` | horizontal | Set angle of reward text
 
 ## Usage
 ```js
@@ -59,6 +61,7 @@ const rewards = [1,2,3,4,5,6,7,8,9,10]
     winner={3}
     innerRadius={50}
     backgroundColor={"#c0392b"}
+    textAngle={"vertical"}
     getWinner={(value, index) => this.setState({ winnerValue: value, winnerIndex: index })}
 />
 <Button title="Press me" onPress={ () => { this.child._onPress() } } />

--- a/src/index.js
+++ b/src/index.js
@@ -128,25 +128,35 @@ class WheelOfFortune extends Component {
 
     };
 
-    _textRender = (x, y, value, size, i) => (
+    _textRender = (x, y, number, i) => (
         <Text
-            x={x}
-            y={y - 70}
+            x={x - number.length * 5}
+            y={y - 80}
             fill={this.props.textColor ? this.props.textColor : '#fff'}
             textAnchor="middle"
             fontSize={this.fontSize}
         >
             {Array.from({ length: number.length }).map((_, j) => {
-                return (
-                    <TSpan
-                        x={x}
-                        dy={this.fontSize}
-                        key={`arc-${i}-slice-${j}`}
-                    >
-
+                // Render reward text vertically
+                if (this.props.textAngle === "vertical") {
+                    return (
+                    <TSpan x={x} dy={this.fontSize} key={`arc-${i}-slice-${j}`}>
                         {number.charAt(j)}
                     </TSpan>
-                );
+                    );
+                }
+                // Render reward text horizontally
+                else {
+                    return (
+                    <TSpan
+                        y={y - 40}
+                        dx={this.fontSize * 0.07}
+                        key={`arc-${i}-slice-${j}`}
+                    >
+                        {number.charAt(j)}
+                    </TSpan>
+                    );
+                }
             })}
         </Text>
     )
@@ -200,27 +210,7 @@ class WheelOfFortune extends Component {
                                             rotation={(i * this.oneTurn) / this.numberOfSegments + this.angleOffset}
                                             origin={`${x}, ${y}`}
                                         >
-
-                                            <Text
-                                                x={x}
-                                                y={y - 50}
-                                                fill={this.props.textColor ? this.props.textColor : '#fff'}
-                                                textAnchor="middle"
-                                                fontSize={this.fontSize}
-                                            >
-                                                {Array.from({ length: number.length }).map((_, j) => {
-                                                    return (
-                                                        <TSpan
-                                                            x={x}
-                                                            dy={this.fontSize}
-                                                            key={`arc-${i}-slice-${j}`}
-                                                        >
-
-                                                            {number.charAt(j)}
-                                                        </TSpan>
-                                                    );
-                                                })}
-                                            </Text>
+                                            {this._textRender(x, y, number, i)}
                                         </G>
                                     </G>
                                 );
@@ -307,7 +297,7 @@ class WheelOfFortune extends Component {
                         {this._renderSvgWheel()}
                     </Animated.View>
                 </TouchableOpacity>
-
+                {this._renderTopToPlay()}
             </View>
         );
     }


### PR DESCRIPTION
Added a new feature which lets you put the reward texts horizontally (see image below). I have also made this a prop so you also could go back to vertical. The Example folder and README have also been edited to adhere to the changes.

I have also edited two render sections, so _renderTopToPlay was used again (deleted in an earlier change, I think by mistake) and _textRender was used instead of a duplicate inline code (unused parameters were also deleted from the function).

Example from own project:
![image](https://user-images.githubusercontent.com/50332377/102722732-6990eb00-4303-11eb-9387-1c387f71e1da.png)
